### PR TITLE
Kevin/2021 08 29 mw-82 fetch large patches

### DIFF
--- a/tap_github/schemas/commits.json
+++ b/tap_github/schemas/commits.json
@@ -127,6 +127,14 @@
               "null",
               "string"
             ]
+          },
+          "isBinary": {
+            "type": ["null", "boolean"],
+            "description": "True if there is no patch because the file is binary (this may be false for renaming binary files because the file isn't inspected in that scenario)."
+          },
+          "isLargeFile": {
+            "type": ["null", "boolean"],
+            "description": "True if there is no patch because the patch was too large to store (> 1 MB)."
           }
         }
       }


### PR DESCRIPTION
# Description of change
Updated tap to fetch raw contents before/after for missing matches for large changes, and then recreate patches for those changes. Note: this doesn't update PR commits, which are going to become shallower in the future.

# Manual QA steps
 - For diff function
   - Tested each of four combinations of new and old files having newlines at end or not to verify the correct behavior similar to git diff with "\ No newline at end of file" token.
   - Verified that content before first @@ is removed
   - Verified that newlines after each @@ line are stripped out
   - Manually compared diff produced for large tap-github-catalog.json change to a diff produced with git diff. Verified that the diff results in the same change set, but observed that the actual diff algorithm is slightly different when changes are ambiguous.
- Overall
  - Ran with all incoming data to verify that patches were imported for the large file changes by querying for changes with filenames singer/tap-jira-catalog.json or singer/tap-github-catalog.json in the imported data.
  - Verified that none of the changes showed up as "isBinary"
  - Set artificially low threshold for "isLargeFile" (10 kb) and verified that it was emitted properly for large changes.
  - Verified that the only changes with empty patches now were renames and an addition of empty and binary files.
  - Edited a binary file to verify that isBinary flag is set to true and patch is empty.
- After merging, will deploy to production and ensure that new data is coming in propely.