### PR TITLE
MW-79 adding branches data source

### DIFF
--- a/tap_github/schemas/branches.json
+++ b/tap_github/schemas/branches.json
@@ -1,0 +1,19 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
+    "name": {
+      "type": ["string"]
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "properties": {
+        "sha": {
+          "type": ["null", "string"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description of change
Adds branches as a data source

# Manual QA steps
 - Verified locally that branches imported successfully from minwareco/scheduled
 - (Didn't deploy since this is a small change).