### PR TITLE
Kevin/2021 09 01 mw 78 commit import changes

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1140,6 +1140,9 @@ def get_all_commits(schema, repo_path,  state, mdata, start_date):
     # Get all of the branch heads to use for querying commits
     heads = get_all_heads_for_commits(repo_path)
 
+    # Set this here for updating the state when we don't run any queries
+    extraction_time = singer.utils.now()
+
     with metrics.record_counter('commits') as counter:
         for head in heads:
             # If the head commit has already been synced, then skip.

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1012,7 +1012,7 @@ def get_all_heads_for_commits(repo_path):
                     'isdefault': isdefault, 'name': branch['name'] }
                 branch_cache[branch['name']] = branch['commit']['sha']
 
-    # Get any additional heads from pull requests -- open and closed
+    # TODO: Get any additional heads from pull requests, both open and closed
     return branch_cache
 
 def get_commit_detail(commit, repo_path):

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -747,9 +747,11 @@ def get_all_pull_requests(schemas, repo_path, state, mdata, start_date):
                 pull_requests = response.json()
                 extraction_time = singer.utils.now()
                 for pr in pull_requests:
-                    # Skip records that haven't been updated since the last run
+                    # Skip records that haven't been updated since the last run because
                     # the GitHub API doesn't currently allow a ?since param for pulls.
-                    # Return early in this case
+                    # Return early in this case to stop querying pages of pull requests.
+                    # PRs get "updated" when the head or base changes, so those commits will have
+                    # been fetched in a previous run.
                     if bookmark_time and singer.utils.strptime_to_utc(pr.get('updated_at')) < bookmark_time:
                         return state
 

--- a/tap_github/schemas/branches.json
+++ b/tap_github/schemas/branches.json
@@ -4,8 +4,14 @@
     "_sdc_repository": {
       "type": ["string"]
     },
+    "repo_name": {
+      "type": ["string"]
+    },
     "name": {
       "type": ["string"]
+    },
+    "isdefault": {
+      "type": ["boolean"]
     },
     "commit": {
       "type": ["null", "object"],

--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -92,6 +92,34 @@
         }
       }
     },
+    "head": {
+      "type": ["null", "object"],
+      "properties": {
+        "ref": {
+          "type": ["null", "string"]
+        },
+        "label": {
+          "type": ["null", "string"]
+        },
+        "repo": {
+          "type": ["null", "object"],
+          "properties": {
+            "id": {
+              "type": [ "null", "integer" ]
+            },
+            "name": {
+              "type": [ "null", "string" ]
+            },
+            "url": {
+              "type": [ "null", "string" ]
+            }
+          }
+        },
+        "sha": {
+          "type": ["null", "string"]
+        }
+      }
+    },
     "merged_at": {
       "type": ["null", "string"],
       "format": "date-time"


### PR DESCRIPTION
# Description of change
Updates the way that bookmarking works for commits to keep going while there are unfetched parents. Also updates the commits stream to fetch all commits starting from all potential heads rather than just the default branch.

# Manual QA steps
 - With scheduled/scheduled, printed out all heads and whether the commits associated with each one had to be fetched or were already in the cache. Also verified that the commits endpoint was not queried when the head was already recorded as fetched in the state. Verified that branch commits were fetched successfully into local database
 - Also running locally, verified that new head props for PR were imported successfully
 - Tested that pushing a new commit to the branch bumps up the branch's update_at parameter.
 - Deployed to production after merging and replaced s_github_2 schema. Queried count(*) from commits, verified it's the same as local: 124.