### PR TITLE
Kevin/2021 11 17 mw 86 fetch local commits

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -929,6 +929,61 @@ def get_all_collaborators(schema, repo_path, state, mdata, _start_date):
 
     return state
 
+
+def create_patch_for_files(old_text, new_text):
+    # Note: this patch may be slightly different from a patch generated with git since the diffing
+    # algorithms aren't the same, but it will at least be correct and in the same format.
+
+    newlineToken = '\\ No newline at end of file'
+    # Add this random data too in the rare case where a file literally ends in the newlineToken but
+    # does have a new line at the end.
+    sentinal = "SDF1G5ALB3YU"
+    newlineMarker = newlineToken + sentinal
+    newlineMarkerLength = len(newlineMarker)
+
+    # Also remove empty lines at end so that they aren't included in the diff output to get the
+    # format to match git's patches.
+
+    oldSplit = old_text.split('\n')
+    if oldSplit[-1] != '':
+        oldSplit[-1] += newlineMarker
+    else:
+        oldSplit = oldSplit[:-1]
+
+    newSplit = new_text.split('\n')
+    if newSplit[-1] != '':
+        newSplit[-1] += newlineMarker
+    else:
+        newSplit = newSplit[:-1]
+
+    # Patches don't use any when coming from the github API, so don't use nay here
+    diff = difflib.unified_diff(oldSplit, newSplit, n=0)
+
+    # Transform this to match the format of git patches coming from the API
+    difflist = list(diff)
+    newDiffList = []
+    firstDiffFound = False
+    for diffLine in difflist:
+        # Skip lines before the first @@
+        if diffLine[0:2] == '@@':
+            firstDiffFound = True
+        if not firstDiffFound:
+            continue
+
+        # Remove extra newlines after each diff line
+        if diffLine[-1:] == '\n':
+            newDiffList.append(diffLine[:-1])
+        # If we found the newline marker at the end, remove it and add the newline token on the next
+        # line like the diff format from github.
+        elif diffLine[-newlineMarkerLength:] == newlineMarker:
+            newDiffList.append(diffLine[:-newlineMarkerLength])
+            newDiffList.append(newlineToken)
+        else:
+            newDiffList.append(diffLine)
+
+    output = '\n'.join(newDiffList)
+    return output
+
 repo_cache = {}
 def get_repo_metadata(repo_path):
     if not repo_path in repo_cache:
@@ -1027,6 +1082,120 @@ def get_all_heads_for_commits(repo_path):
         head_set[val['base_sha']] = 1
     return head_set.keys()
 
+def get_commit_detail(commit, repo_path):
+    '''
+    # Augment each commit with overall stats and file-level diff data by hitting the commits
+    # endpoint with the individual commit hash.
+    # This is copied from the github documentation:
+    # Note: If there are more than 300 files in the commit diff, the response will
+    # include pagination link headers for the remaining files, up to a limit of 3000
+    # files. Each page contains the static commit information, and the only changes are
+    # to the file listing.
+    # TODO: if the changed file count exceeds 3000, then use the raw checkout to fetch
+    # this data.
+    '''
+
+    # Hash of file addition that's too large, for testing
+    #if commit['sha'] != '836f0c47362e2f92f57ddee977df0f5c0da6d53b':
+    #    continue
+    # Hash of commit with file change that's too large, for testing
+    #if commit['sha'] != '1961e1b44e7c15b1f62f6da99b0e284b71d64048':
+    #    continue
+
+    commit['files'] = []
+    for commit_detail in authed_get_all_pages(
+        'commits',
+        'https://api.github.com/repos/{}/commits/{}'.format(repo_path, commit['sha'])
+    ):
+        # TODO: test fetching multiple pages of changed files if the changed file count
+        # exceeds 300.
+        detail_json = commit_detail.json()
+        commit['stats'] = detail_json['stats']
+        commit['files'].extend(detail_json['files'])
+
+    # Iterate through each of the file changes and fetch the raw patch if it is missing
+    # because it is too big of a change
+    for commitFile in commit['files']:
+        commitFile['isBinary'] = False
+        commitFile['isLargeFile'] = False
+        commitFile['isError'] = False
+
+        # Skip if there's already a patch
+        if 'patch' in commitFile:
+            continue
+        # If no changes are showing, this is probably a binary file
+        if commitFile['changes'] == 0 and commitFile['additions'] == 0 and \
+                commitFile['deletions'] == 0:
+            # Indicate that this file is binary if it's "modified" and the change
+            # counts are zero. Change counts can be zero for other reasons with renames
+            # and additions/deletions of empty files
+            if commitFile['status'] == 'modified':
+                commitFile['isBinary'] = True
+            continue
+
+        # Patch is missing for large file, get the urls of the current and previous
+        # raw change blobs
+        currentContentsUrl = commitFile['contents_url']
+
+        try:
+            for currentContents in authed_get_all_pages(
+                'file_contents',
+                currentContentsUrl
+            ):
+                currentContentsJson = currentContents.json()
+                fileContent = currentContentsJson['content']
+                    # TODO: do we need to catch base64 decode errors in case file is binary?
+                decodedFileContent = base64.b64decode(fileContent).decode("utf-8")
+                # Will only be one page
+                break
+
+            # Get the previous contents if the file existed before (not added)
+            decodedPreviousFileContent = ''
+            if commitFile['status'] != 'added':
+                contentPath = currentContentsUrl.split('?ref=')[0]
+                # First parent is base, second parent is head
+                baseSha = commit['parents'][0]['sha']
+                if 'previous_filename' in commitFile:
+                    contentPath = contentPath.replace(commitFile['filename'],
+                        commitFile['previous_filename'])
+                previousContentsUrl = contentPath + '?ref=' + baseSha
+
+                for previousContents in authed_get_all_pages(
+                    'file_contents',
+                    previousContentsUrl
+                ):
+                    previousContentsJson = previousContents.json()
+                    previousFileContent = previousContentsJson['content']
+                    # TODO: do we need to catch base64 decode errors in case file is binary?
+                    decodedPreviousFileContent = base64.b64decode(previousFileContent).decode("utf-8")
+                    # Will only be one page
+                    break
+
+            patch = create_patch_for_files(decodedPreviousFileContent, decodedFileContent)
+            if len(patch) > LARGE_FILE_DIFF_THRESHOLD:
+                commitFile['isLargeFile'] = True
+            else:
+                commitFile['patch'] = patch
+        except NotFoundException as err:
+            logger.info('Encountered 404 while fetching blob. Flagging as large file and ' \
+                'skipping. Original exception: ' + repr(err))
+            commitFile['isError'] = True
+        except AuthException as err:
+            # Original error:
+            # {'message': 'This API returns blobs up to 1 MB in size. The requested blob is too
+            # large to fetch via the API, but you can use the Git Data API to request blobs up to
+            # 100 MB in size.', 'errors': [{'resource': 'Blob', 'field': 'data', 'code':
+            # 'too_large'}], 'documentation_url':
+            # 'https://docs.github.com/rest/reference/repos#get-repository-content'}
+            logger.info('Encountered 403 while fetching blob, which likely means it is too '\
+                'large. Treating as large file and skipping. Original excpetion: ' + repr(err))
+            commitFile['isLargeFile'] = True
+
+
+# Diffs over this many bytes of text are dropped and instead replaced with a flag indicating that
+# the file is large.
+LARGE_FILE_DIFF_THRESHOLD = 1024 * 1024
+
 def get_all_commits(schema, repo_path,  state, mdata, start_date):
     '''
     https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
@@ -1077,6 +1246,89 @@ def get_all_commits(schema, repo_path,  state, mdata, start_date):
                     # Skip commits we've already imported
                     if commit['sha'] in fetchedCommits:
                         continue
+                    commit['_sdc_repository'] = repo_path
+                    with singer.Transformer() as transformer:
+                        rec = transformer.transform(commit, schema, metadata=metadata.to_map(mdata))
+                    singer.write_record('commits', rec, time_extracted=extraction_time)
+
+                    # Record that we have now fetched this commit
+                    fetchedCommits[commit['sha']] = 1
+                    # No longer a missing parent
+                    missingParents.pop(commit['sha'], None)
+
+                    # Keep track of new missing parents
+                    for parent in commit['parents']:
+                        if not parent['sha'] in fetchedCommits:
+                            missingParents[parent['sha']] = 1
+                    counter.increment()
+
+                # If there are no missing parents, then we are done prior to reaching the lst page
+                if not missingParents:
+                    break
+                elif 'next' in response.links:
+                    cururl = response.links['next']['url']
+                # Else if we have reached the end of our data but not found the parents, then we
+                # have a problem
+                else:
+                    raise GithubException('Some commit parents never found: ' + \
+                        ','.join(missingParents.keys()))
+
+    # Don't write until the end so that we don't record fetchedCommits if we fail and never get
+    # their parents.
+    singer.write_bookmark(state, repo_path, 'commits', {
+        'since': singer.utils.strftime(extraction_time),
+        'fetchedCommits': fetchedCommits
+    })
+
+    return state
+
+def get_all_commit_files(schema, repo_path,  state, mdata, start_date):
+    bookmark = get_bookmark(state, repo_path, "commit_files", "since", start_date)
+    if not bookmark:
+        bookmark = '1970-01-01'
+
+    # Get the set of all commits we have fetched previously
+    fetchedCommits = get_bookmark(state, repo_path, "commits", "fetchedCommits")
+    if not fetchedCommits:
+        fetchedCommits = {}
+    else:
+        # We have run previously, so we don't want to use the time-based bookmark becuase it could
+        # skip commits that are pushed after they are committed. So, reset the 'since' bookmark back
+        # to the beginning of time and rely solely on the fetchedCommits bookmark.
+        bookmark = '1970-01-01'
+
+    # We don't want newly fetched commits to update the state if we fail partway through, because
+    # this could lead to commits getting marked as fetched when their parents are never fetched. So,
+    # copy the dict.
+    fetchedCommits = fetchedCommits.copy()
+
+    # Get all of the branch heads to use for querying commits
+    heads = get_all_heads_for_commits(repo_path)
+
+    # Set this here for updating the state when we don't run any queries
+    extraction_time = singer.utils.now()
+
+    with metrics.record_counter('commits') as counter:
+        for head in heads:
+            # If the head commit has already been synced, then skip.
+            if head in fetchedCommits:
+                continue
+
+            # Maintain a list of parents we are waiting to see
+            missingParents = {}
+
+            cururl = 'https://api.github.com/repos/{}/commits?per_page=100&sha={}&since={}' \
+                .format(repo_path, head, bookmark)
+            while True:
+                # Get commits one page at a time
+                response = list(authed_get_yield('commits', cururl))[0]
+                commits = response.json()
+                extraction_time = singer.utils.now()
+                for commit in commits:
+                    # Skip commits we've already imported
+                    if commit['sha'] in fetchedCommits:
+                        continue
+                    get_commit_detail(commit, repo_path)
                     commit['_sdc_repository'] = repo_path
                     with singer.Transformer() as transformer:
                         rec = transformer.transform(commit, schema, metadata=metadata.to_map(mdata))
@@ -1227,6 +1479,7 @@ def get_stream_from_catalog(stream_id, catalog):
 SYNC_FUNCTIONS = {
     'branches': get_all_branches,
     'commits': get_all_commits,
+    'commit_files': get_all_commit_files,
     'comments': get_all_comments,
     'issues': get_all_issues,
     'assignees': get_all_assignees,

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1211,7 +1211,6 @@ def get_commit_detail_local(commit, repo_path, gitLocal):
         raise e
 
 def get_commit_changes(commit, repo_path, useLocal, gitLocal):
-    logger.info('A: ' + commit['sha'])
     if useLocal:
         get_commit_detail_local(commit, repo_path, gitLocal)
     else:
@@ -1230,7 +1229,6 @@ def get_commit_changes(commit, repo_path, useLocal, gitLocal):
             else:
                 commitFile['changetype'] = 'none'
             commitFile['commit_sha'] = commit['sha']
-    logger.info('B: ' + commit['sha'])
     return commit['files']
 
 def get_all_commits(schema, repo_path,  state, mdata, start_date):

--- a/tap_github/gitlocal.py
+++ b/tap_github/gitlocal.py
@@ -1,0 +1,333 @@
+import subprocess
+import sys
+import os
+import re
+import json
+
+class GitLocalException(Exception):
+  pass
+
+def parseDiffLines(lines):
+  changes = []
+  curChange = None
+  state = 'start'
+  lastDiffLine = ''
+  for line in lines:
+    if len(line) == 0:
+      # Only happens on last line -- other blank lines at least start with space
+      if curChange:
+        changes.append(curChange)
+        curChange = None
+      continue
+    elif line[0:4] == 'diff': # diff
+      lastDiffLine = line
+      # For a pure file mode change, the change type will be none without a patch. Convert this to
+      # an edit.
+      if curChange and (curChange['changetype'] != 'none' or len(curChange['patch']) > 0 or \
+          curChange['is_binary'] or curChange['previous_filename']):
+        changes.append(curChange)
+      curChange = {
+        'filename': '',
+        'additions': 0,
+        'deletions': 0,
+        'patch': [],
+        'previous_filename': '',
+        'is_binary': False,
+        'is_large_patch': False,
+        'changetype': 'none',
+      }
+      state = 'start'
+      pass
+    elif state == 'inpatch':
+      if line[0] == '@':
+        # Note: this line may have context at the end, which is okay and part of the git difff
+        # format.
+        curChange['patch'].append(line)
+      else:
+        if line[0] == '-':
+          curChange['deletions'] += 1
+        elif line[0] == '+':
+          curChange['additions'] += 1
+        curChange['patch'].append(line)
+    elif line[0] == 'i': # index
+      # Ignore file mode changes for now
+      pass
+    elif line[0] == 's': # similarity index...
+      pass
+    elif line[0] == 'o': # old mode...
+      pass
+    elif line[0] == 'n': # new file/mode...
+      if line[:8] == 'new mode':
+        curChange['changetype'] = 'edit'
+      else:
+        curChange['changetype'] = 'add'
+      # If the file is empty or binary, this is the way to get the file name. If this is a mode
+      # change with a rename, then this will get overwritten by the rename lines that follow
+      fileNameLen = int((len(lastDiffLine) - len('diff --git a/ b/')) / 2)
+      curChange['filename'] = lastDiffLine[-fileNameLen:]
+    elif line[0:3] == 'del': # deleted file
+      curChange['changetype'] = 'delete'
+      # We won't have anything to identify the file other than the first diff line. For this line,
+      # the file name will be the same with a/ and b/, so do this trick to figure out its length
+      # (which we need to do because the file name can have " b/" inside of it)
+      fileNameLen = int((len(lastDiffLine) - len('diff --git a/ b/')) / 2)
+      curChange['filename'] = lastDiffLine[-fileNameLen:]
+    elif line[0] == 'B': # Binary files dffer
+      curChange['is_binary'] = True
+      pass
+    elif line[0] == 'r': # rename from/to...
+      if line[0:12] == 'rename from ':
+        curChange['previous_filename'] = line[12:]
+      elif line[0:10] == 'rename to ':
+        # Need to save this here becuase a pure rename won't have a +++ line
+        curChange['filename'] = line[10:]
+    elif line[0] == '-':
+      pass # Ignore, will be same as rename from if different from changed file name
+    elif line[0] == '+':
+      # May already be set for a delete or add
+      if not curChange['filename']:
+        curChange['filename'] = line.replace('+++ b/', '')
+      state = 'inpatch'
+    else:
+      raise GitLocalException('Unexpected line start: "{}"'.format(line))
+  for change in changes:
+    change['patch'] = '\n'.join(change['patch'])
+    if len(change['patch']) == 0:
+      change['patch'] = None
+    elif len(change['patch']) > 1024 * 1024:
+      change['patch'] = None
+      change['is_large_patch'] = True
+
+    if (change['is_binary'] or change['is_large_patch'] or change['patch']) \
+        and change['changetype'] == 'none':
+      change['changetype'] = 'edit'
+
+    # This isn't strictly necessary, but doing it to make sure that the output is exactly the same
+    # as when using the API.
+    if not change['previous_filename']:
+      del change['previous_filename']
+    if not change['patch']:
+      del change['patch']
+  return changes
+
+
+class GitLocal:
+  def __init__(self, config):
+    self.token = config['access_token']
+    self.workingDir = config['workingDir']
+    self.LS_CACHE = {}
+    self.INIT_REPO = {}
+
+  def getOrgWorkingDir(self, repo):
+    orgName = repo.split('/')[0]
+    orgWdir = '{}/{}'.format(self.workingDir, orgName)
+    if not os.path.exists(orgWdir):
+      os.mkdir(orgWdir)
+    return orgWdir
+
+  def getRepoWorkingDir(self, repo):
+    orgDir = self.getOrgWorkingDir(repo)
+    repoDir = repo.split('/')[1]
+    return '{}/{}'.format(orgDir, repoDir)
+
+  def cloneRepo(self, repo, failOnExists=False):
+    """
+    Clones a repository using git clone, throwing an error if the operation does not succeed
+    """
+    if os.path.exists(self.getRepoWorkingDir(repo)):
+      if failOnExists:
+        raise GitLocalException("Attempted to clone repo {} that already exists".format(repo))
+      else:
+        return
+
+    cloneUrl = "https://{}@github.com/{}.git".format(self.token, repo)
+    orgDir = self.getOrgWorkingDir(repo)
+    completed = subprocess.run(['git', 'clone', cloneUrl], cwd=orgDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Clone of repo {} failed with code {}, message: {}".format(repo,
+        completed.returncode, strippedOutput))
+
+  def initRepo(self, repo):
+    if repo in self.INIT_REPO:
+      return
+
+    self.cloneRepo(repo)
+
+    # In case a previous run was killed in the middle of anything, do a hard reset of the repo
+    # directory
+    repoDir = self.getRepoWorkingDir(repo)
+    subprocess.run(['git', 'clean', '-fd'], cwd=repoDir, capture_output=True)
+    subprocess.run(['git', 'reset', '--hard'], cwd=repoDir, capture_output=True)
+
+    self.INIT_REPO[repo] = True
+
+  def checkoutCommit(self, repo, sha, raiseOnError=True):
+    """
+    Checks out a commit, returning True if successful and False on failure. Will throw an exception
+    if there's a failure unless raiseOnError is set to False.
+    """
+    # Clone if necessary
+    self.initRepo(repo)
+    repoDir = self.getRepoWorkingDir(repo)
+    completed = subprocess.run(['git', 'checkout', sha], cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      if not raiseOnError:
+        return False
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Checkout of repo {}, sha {} failed with code {}, message: {}".format(
+        repo, sha, completed.returncode, strippedOutput))
+    return True
+
+  def lsRemote(self, repo):
+    if repo in self.LS_CACHE:
+      return self.LS_CACHE[repo]
+
+    self.initRepo(repo)
+    repoDir = self.getRepoWorkingDir(repo)
+    completed = subprocess.run(['git', 'ls-remote'], cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("ls-remote of repo {} failed with code {}, message: {}".format(
+        repo, completed.returncode, strippedOutput))
+
+    outstr = completed.stdout.decode('utf8')
+
+    refmap = {}
+    for m in re.finditer( r'([0-9a-f]{40})\s+([^\n]+)(.*?)', outstr):
+      hash = m.group(1)
+      ref = m.group(2)
+      refmap[ref] = hash
+
+    self.LS_CACHE[repo] = refmap
+    return refmap
+
+  def fetchRemote(self, repo, ref):
+    self.initRepo(repo)
+    repoDir = self.getRepoWorkingDir(repo)
+    sys.stderr.write('fetching remote ref {}\n'.format(ref))
+    completed = subprocess.run(['git', 'fetch', 'origin', ref], cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Fetch from origin of repo {}, ref {} failed with code {}, "\
+        "message: {}".format(repo, ref, completed.returncode, strippedOutput))
+
+  def fetchRef(self, repo, ref, sha):
+    """
+    Attempt to fetch a named ref that is or was associated with a particular SHA.
+    """
+    # First, just try to check out the commit from what we already have
+    success = self.checkoutCommit(repo, sha, False)
+    if success:
+      return True
+
+    # Now see if the ref is in the remote ref map
+    refmap = self.lsRemote(repo)
+    # If it is, fetch it
+    if ref in refmap:
+      self.fetchRemote(repo, ref)
+
+    # Now try checking out the sha again
+    success = self.checkoutCommit(repo, sha, False)
+    return success
+
+  def getCommitsFromHead(self, repo, headSha):
+    """
+    This function lists multiple commits, but it has a few limitations based on missing data from
+    github: (1) it can't fill in the comment count, (2) it doesn't know the github user IDs and
+    user names associated wtih the commit.
+    """
+    self.checkoutCommit(repo, headSha)
+    repoDir = self.getRepoWorkingDir(repo)
+    # Since git log can't escape stuff, create unique sentinals
+    startTok = 'xstart5147587x'
+    sepTok = 'xsep4983782x'
+    completed = subprocess.run(['git', 'log', '--pretty={}{}'.format(
+      startTok,
+      sepTok.join(['%H','%T','%P','%an','%ae','%ai','%cn','%ce','%ci','%B'])
+    )], cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Log of repo {}, sha {} failed with code {}, message: {}".format(
+        repo, headSha, completed.returncode, strippedOutput))
+    outstr = completed.stdout.decode('utf8')
+    commitLines = outstr.split(startTok)
+    commits = []
+    for rawCommit in commitLines:
+      # Strip off trailing newline as well
+      split = rawCommit.rstrip().split(sepTok)
+      if len(split) < 2:
+        continue
+      commits.append({
+        '_sdc_repository': repo,
+        'sha': split[0],
+        'commit': {
+          'author': {
+            'name': split[3],
+            'email': split[4],
+            'date': split[5],
+          },
+          'committer': {
+            'name': split[6],
+            'email': split[7],
+            'date': split[8],
+          },
+          'tree': {
+            'sha': split[1],
+            'url': 'https://api.github.com/repos/{}//git/trees/{}'.format(repo, split[1]),
+          },
+          'url': 'https://api.github.com/repos/{}/commits/{}'.format(repo, split[0]),
+          # Omit comment_count, since comments are a github thing
+          # Omit 'verification' since we don't care about signatures right now
+        },
+        # Omit node_id, since we strip it out
+        'url': 'https://api.github.com/repos/{}/commits/{}'.format(repo, split[0]),
+        'html_url': 'https://api.github.com/repos/{}/commits/{}'.format(repo, split[0]),
+        'comments_url': 'https://api.github.com/repos/{}/commits/{}/comments'.format(repo, split[0]),
+        # author and committer may also exist here in github along with info about github user IDs.
+        # We can't include those becuase we don't know them.
+        # TODO: import these somehow, since they are the one and only mapping between github user
+        # IDs and what is in the git log.
+        'parents': [] if split[2] == '' else ({
+          'sha': p,
+          'url': 'https://api.github.com/repos/{}/commits/{}'.format(repo, p),
+          'html_url': 'https://github.com/{}/commit/{}'.format(repo, p)
+        } for p in split[2].split(' ')),
+        # Leave stats empty -- it isn't included when listing multiple commits
+        # Leave files empty -- it isn't included when listing multiple commits
+      })
+    return commits
+
+  def getCommitDiff(self, repo, sha):
+    """
+    Gets detailed information about a commit at a particular sha
+    """
+    #self.checkoutCommit(repo, sha)
+    repoDir = self.getRepoWorkingDir(repo)
+    completed = subprocess.run(['git', 'diff', sha + '~1', sha], cwd=repoDir, capture_output=True)
+    # Special case -- first commit, diff instead with an empty tree
+    if completed.returncode != 0 and b"~1': unknown revision or path not in the working tree" \
+        in completed.stderr:
+      # 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is the sha of the empty tree
+      completed = subprocess.run(['git', 'diff', '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+        sha], cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = '' if not completed.stderr else \
+        completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Diff of repo {}, sha {} failed with code {}, message: {}".format(
+        repo, sha, completed.returncode, strippedOutput))
+
+    outstr = completed.stdout.decode('utf8')
+    lines = outstr.split('\n')
+
+    parsed = parseDiffLines(lines)
+    for diff in parsed:
+      diff['commit_sha'] = sha
+
+    return parsed

--- a/tap_github/schemas/commit_files.json
+++ b/tap_github/schemas/commit_files.json
@@ -1,0 +1,50 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {
+      "type": ["string"],
+      "description": "Unique identifier of the commit change '{_sdc_repository}/{commit_sha}/{file_path}'."
+    },
+    "_sdc_repository": {
+      "type": ["string"],
+      "description": "The repository of the commit for this commit file."
+    },
+    "commit_sha": {
+      "type": ["string"],
+      "description": "The hash of the commit. May not be unique if there are multiple forked repos of the same base repo, potentially in different orgs or different sources for the same org."
+    },
+    "filename": {
+      "type": ["string"],
+      "description": "The full name of the file including its directory path."
+    },
+
+    "previous_filename": {
+      "type": ["null", "string"],
+      "description": "If the file was renamed, this was its full name in the parent commit"
+    },
+    "patch": {
+      "type": ["null", "string"],
+      "description": "A patch representing the changes to the file in this commit."
+    },
+    "is_binary": {
+      "type": ["boolean"],
+      "description": "The file is binary, so no patch is included and change counts are zero. Binary is determined by the presence of null bytes or sequences that cause UTF-8 decoding errors. This flag will not be set when adding binary files becuase those are indiscernable from adding zero-length files in the github api."
+    },
+    "is_large_patch": {
+      "type": ["boolean"],
+      "description": "The file is text, but the current patch was too large to include (> 1 MB). Change counts may or may not be non-zero."
+    },
+    "changetype": {
+      "type": ["string"],
+      "description": "The type of change -- one of: add, delete, edit, none. None means no change to the file, which may be the case if there's a rename."
+    },
+    "additions": {
+      "type": ["integer"],
+      "description": "The number of lines added by this change (0 for binary or large patch)."
+    },
+    "deletions": {
+      "type": ["integer"],
+      "description": "The number of lines deleted by this change (0 for binary or large patch)."
+    }
+  }
+}


### PR DESCRIPTION
Adds the commit_files schema and processes it using local git so that it is faster and doesn't use up the API rate limit

## How was this tested?
- Ran against scheduled and repotest to verify that changes to the output were desirable compared to the output that comes from pulling the same data from the github API.