### PR TITLE
changing git local to use mirrored clone

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1422,7 +1422,7 @@ async def get_all_commit_files(schema, repo_path,  state, mdata, start_date, git
         # Run in batches
         i = 0
         BATCH_SIZE = 256
-        PRINT_INTERVAL = 5
+        PRINT_INTERVAL = 1
         hasLocal = True # Only local now
         while i * BATCH_SIZE < len(commitQ):
             curQ = commitQ[i * BATCH_SIZE:(i + 1) * BATCH_SIZE]

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1421,7 +1421,7 @@ async def get_all_commit_files(schema, repo_path,  state, mdata, start_date, git
 
         # Run in batches
         i = 0
-        BATCH_SIZE = 256
+        BATCH_SIZE = 512
         PRINT_INTERVAL = 1
         hasLocal = True # Only local now
         while i * BATCH_SIZE < len(commitQ):


### PR DESCRIPTION
Updates the local git to do a full mirror on the clone so that it's not necessary to do any fetches. This should also get us *all* of the commits and eliminate the need to pull anything from github's API, which has now been disabled.

## How has this been tested?
- Ran on a clean temp dir for ec2sw, completed the whole import (to outfile) in 2m 25s, observed no warnings about missing commits
- Ran on existing checkout for ec2sw, completed the whole import (to outfile) in 1m 52s initially, down to about 1m 30s after optimizing parallel processing, 25s of which was just getting all of the commit lists from the heads.