### PR TITLE
getting heads locally and adding other stuff to the schema that wasn'…

### DIFF
--- a/tap_github/schemas/commit_files.json
+++ b/tap_github/schemas/commit_files.json
@@ -12,6 +12,74 @@
       "type": ["null", "string"],
       "description": "The git commit hash"
     },
+    "parents": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "sha": {
+            "type": ["null", "string"],
+            "description": "The git hash of the parent commit"
+          }
+        }
+      }
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "properties": {
+        "tree": {
+          "type": ["null", "object"],
+          "properties": {
+            "sha": {
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "author": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the author committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The author's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The author's email"
+            }
+          }
+        },
+        "message": {
+          "type": ["null", "string"],
+          "description": "The commit message"
+        },
+        "committer": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the committer committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The committer's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The committer's email"
+            }
+          }
+        }
+      }
+    },
     "files": {
       "type": ["array"],
       "items": {

--- a/tap_github/schemas/refs.json
+++ b/tap_github/schemas/refs.json
@@ -1,0 +1,16 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
+    "ref": {
+      "type": ["string"],
+      "description": "The name of the ref"
+    },
+    "sha": {
+      "type": ["null", "string"],
+      "description": "The ref's commit hash"
+    }
+  }
+}


### PR DESCRIPTION
Fixes a memory leak, gets refs from local repo, and now includes refs and commit details in the output.

## How was this tested?
 - Ran locally on ec2sw, looked at out file to verify that new refs and commit fields were included correctly. The whole job now runs in about 1 minute for an existing checkout of ec2sw after this change.