### PR TITLE
fixing pr state issue

### DIFF
--- a/tap_github/gitlocal.py
+++ b/tap_github/gitlocal.py
@@ -1,3 +1,6 @@
+# TODO: consolidate this with gitlab's copy:
+# https://minware.atlassian.net/browse/MW-258
+
 import subprocess
 import sys
 import os


### PR DESCRIPTION
Fixes a bug where PR bookmarks can get written out, subsequent commits fail, and then they never get loaded due to missing PR heads.

## How was this tested?
- Just going to run in production and verify that we're no longer importing all of the PRs.