### PR TITLE
Eliminate git log bottneck, add more logging 

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1405,7 +1405,7 @@ def get_all_commit_files(schemas, repo_path,  state, mdata, start_date, gitLocal
 
     count = 0
     # The lage majority of PRs are less than this many commits
-    LOG_PAGE_SIZE = 20
+    LOG_PAGE_SIZE = 10000
     with metrics.record_counter('commit_files') as counter:
         # First, walk through all the heads and queue up all the commits that need to be imported
         commitQ = []


### PR DESCRIPTION
# Description of change
Eliminate a large bottleneck caused by usage of `git log` with a small page size. Simply increasing the page size to 10k reduces the processing time from 12 hours down to ~2 minutes.

Add a few log messages for ease of debugging and profiling.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
