### PR TITLE
Kevin/2022 04 25 mw 394 app ingest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(name='tap-github',
           'singer-python==5.12.1',
           'requests==2.20.0',
           'psutil==5.8.0',
-          'debugpy==1.5.1'
+          'debugpy==1.5.1',
+          'PyJWT==2.3.0'
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(name='tap-github',
           'requests==2.20.0',
           'psutil==5.8.0',
           'debugpy==1.5.1',
-          'PyJWT==2.3.0'
+          'PyJWT==2.3.0',
+          'cryptography==36.0.2'
       ],
       extras_require={
           'dev': [

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1,5 +1,4 @@
 import argparse
-from gettext import install
 import os
 import json
 import collections

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -486,7 +486,7 @@ def refresh_app_token(pem=None, appid=None, org=None):
     installation_id = cached_installations[org]
     installation_token = get_installation_token(installation_id)
 
-    # Now we have a token we can just the same way that we use a personal access token
+    # Now we have a token we can just use the same way that we use a personal access token
     # Expired token for testing:
     #installation_token = 'ghs_IIfqB0qB286kuZkFdLQYcznyTEToYG3YGAxJ'
 

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -401,8 +401,10 @@ def fetch_installations():
     Before this function is called, an authorization header with a JWT bearer token should be set in
     the session.
     '''
+    logger.info('Fetching installations')
+    return []
 
-cached_installations
+cached_installations = False
 def set_auth_headers(config):
     access_token = config['access_token']
     # If we don't have a personal access token, use the github app
@@ -417,6 +419,7 @@ def set_auth_headers(config):
 
     session.headers.update({'authorization': 'token ' + access_token})
 
+    sys.exit(0)
     return access_token
 
 
@@ -1797,7 +1800,7 @@ def main():
         do_discover(args.config)
     else:
         catalog = args.properties if args.properties else get_catalog()
-        #do_sync(args.config, args.state, catalog)
+        do_sync(args.config, args.state, catalog)
 
 if __name__ == "__main__":
     main()

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -416,7 +416,6 @@ def fetch_installations():
     the session.
     '''
     logger.info('Fetching installations')
-    session.headers.update({'per_page': '1', 'page': '1'})
 
     # This obviously won't scale. As one step toward scaling, we may want to cache this mapping in
     # the state file and only fetch new ones. As a long-term solution, we will need to maintain a

--- a/tap_github/gitlocal.py
+++ b/tap_github/gitlocal.py
@@ -14,7 +14,7 @@ class GitLocalException(Exception):
 logger = singer.get_logger()
 
 def parseDiffLines(lines):
-  logger.info("parseDiffLines() called for %d lines", len(lines))
+  #ogger.info("parseDiffLines() called for %d lines", len(lines))
   changes = []
   curChange = None
   state = 'start'
@@ -145,7 +145,8 @@ class GitLocal:
           .format(repo, completed.returncode, strippedOutput))
     else:
       logger.info("Running git clone")
-      cloneUrl = "https://{}@github.com/{}.git".format(self.token, repo)
+      cloneUrl = "https://x-access-token:{}@github.com/{}.git".format(self.token, repo)
+      logger.info(cloneUrl);
       orgDir = self._getOrgWorkingDir(repo)
       completed = subprocess.run(['git', 'clone', '--mirror', cloneUrl], cwd=orgDir,
         capture_output=True)
@@ -249,7 +250,7 @@ class GitLocal:
     head has already been fetched and this commit is available.
     """
     repoDir = self._getRepoWorkingDir(repo)
-    logger.info("Running git diff for %s", sha)
+    #ogger.info("Running git diff for %s", sha)
     completed = subprocess.run(['git', 'diff', sha + '~1', sha], cwd=repoDir, capture_output=True)
     # Special case -- first commit, diff instead with an empty tree
     if completed.returncode != 0 and b"~1': unknown revision or path not in the working tree" \


### PR DESCRIPTION
Adds support for github application authorization instead of using personal access tokens

## How was this tested?
- Executed on repotest with outfile for regular and files version of the tap with an existing personal access token to verify that the output file looked correct.
- Executed on repotest with outfile for regular and files version of the tap without a personal access token and including an app id/pem to verify that the output file had the same amount of data for both runs.
- Ran with star repo selector for minwareco and github.files to verify that it imported data from all 21 repos as expected.