### PR TITLE
Kevin/2022 04 26 mw 394 fix org case

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -504,7 +504,6 @@ def getReposForOrg(org):
             namesplit = repo['full_name'].split('/')
             orgRepos.append(org + '/' + namesplit[1])
 
-    logger.info(orgRepos)
     return orgRepos
 
 def set_auth_headers(config, repo):

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -429,7 +429,7 @@ def fetch_installations():
     ):
         installations = response.json()
         for installation in installations:
-            account_to_installation[installation['account']['login']] = installation['id']
+            account_to_installation[installation['account']['login'].lower()] = installation['id']
 
     return account_to_installation
 
@@ -480,10 +480,10 @@ def refresh_app_token(pem=None, appid=None, org=None):
         cached_installations = fetch_installations()
 
     # And make sure we have an installation for this org
-    if not cached_installations.get(org):
+    if not cached_installations.get(org.lower()):
         raise NotFoundException('No app installation found for org ' + org)
 
-    installation_id = cached_installations[org]
+    installation_id = cached_installations[org.lower()]
     installation_token = get_installation_token(installation_id)
 
     # Now we have a token we can just use the same way that we use a personal access token
@@ -500,7 +500,9 @@ def getReposForOrg(org):
     ):
         repos = response.json()
         for repo in repos['repositories']:
-            orgRepos.append(repo['full_name'])
+            # Preserve the case used for the org name originally
+            namesplit = repo['full_name'].split('/')
+            orgRepos.append(org + '/' + namesplit[1])
 
     logger.info(orgRepos)
     return orgRepos


### PR DESCRIPTION
Fixes bug with the case of the org that was causing the state files to be ignored when importing data with the github tap and leading to the execution taking forever.

## How was this tested?
- Provided "shootproof", which was used originally despite the canonical case being "ShootProof", then observed that the repo names started with "shootproof/..." again.