### PR TITLE
handling 404 error on teams gracefully

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -593,6 +593,11 @@ def get_all_teams(schemas, repo_path, state, mdata, _start_date):
             logger.info('Received 403 unauthorized while trying to access teams. You must' \
                     ' have admin access to load teams, skipping stream for repo {}.'\
                     .format(repo_path))
+        except NotFoundException as err:
+            # This can happen for individual accounts, so ignore in that case
+            logger.info('Received 404 not found while trying to access teams. This may be a ' \
+                    'personal account without teams. Skipping stream for repo {}.'\
+                    .format(repo_path))
 
     return state
 


### PR DESCRIPTION
Fixes the issue where personal repositories were failing due to 404 errors on the teams endpoint. Updated the tap to just skip data in that case.

# How was this tested?
- Re-ran tj/commander.js, which was previously failing, and confirmed that it finished successfully when writing to outfile and running locally.