### PR TITLE
changing unique commit key to ID

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -24,7 +24,7 @@ REQUIRED_CONFIG_KEYS = ['start_date', 'access_token', 'repository']
 
 KEY_PROPERTIES = {
     'branches': ['repo_name'],
-    'commits': ['sha'],
+    'commits': ['id'],
     'commit_files': ['id'],
     'comments': ['id'],
     'issues': ['id'],
@@ -1300,6 +1300,7 @@ def get_all_commits(schema, repo_path,  state, mdata, start_date):
                     if commit['sha'] in fetchedCommits:
                         continue
                     commit['_sdc_repository'] = repo_path
+                    commit['id'] = '{}/{}'.format(repo_path, commit['sha'])
                     with singer.Transformer() as transformer:
                         rec = transformer.transform(commit, schema, metadata=metadata.to_map(mdata))
                     singer.write_record('commits', rec, time_extracted=extraction_time)

--- a/tap_github/schemas/commits.json
+++ b/tap_github/schemas/commits.json
@@ -4,6 +4,10 @@
     "_sdc_repository": {
       "type": ["string"]
     },
+    "id": {
+      "type": ["string"],
+      "description": "Unique identifier of commit, <_sdc_repository>/<sha>"
+    },
     "sha": {
       "type": ["null", "string"],
       "description": "The git commit hash"


### PR DESCRIPTION
Changes the unique key for commits from SHA to ID (repo/sha) to avoid problems with forked repos not importing properly.

## How was this tested?
- Ran locally with outfile to observe that the schema and records properly updated to use the ID as the unique key for the commits stream.