### PR TITLE
Nick/mw 696 fix auth token rate limit

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -558,7 +558,7 @@ def set_auth_headers(config, org = None):
     if not access_token or len(access_token) == 0:
         if not org:
             raise Exception('Org value must be provided when authorizing with an app installation key')
-        elif cached_app_tokens[org]:
+        elif org in cached_app_tokens:
             return cached_app_tokens[org]
         pem = config['app_pem']
         appid = config['app_id']


### PR DESCRIPTION
# Description of change
Fix a problem where the app installation auth token was being requested repeatedly and in some cases tripping a rate limit.

https://minware.atlassian.net/browse/MW-696

# Manual QA steps
- Ran `reposync` in dev environment with some additional logging to ensure that the auth token is no longer requested repeatedly for a single org.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
