### PR TITLE
Kevin/2022 09 20 mw 752 azure git files

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1962,7 +1962,7 @@ def do_sync(config, state, catalog):
         gitLocal = GitLocal({
             'access_token': access_token,
             'workingDir': '/tmp'
-        })
+        }, 'github')
 
         for stream in catalog['streams']:
             stream_id = stream['tap_stream_id']

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1962,7 +1962,8 @@ def do_sync(config, state, catalog):
         gitLocal = GitLocal({
             'access_token': access_token,
             'workingDir': '/tmp'
-        }, 'github')
+        }, 'https://x-access-token:{}@github.com/{}.git',
+            config['hmac_token'] if 'hmac_token' in config else None)
 
         for stream in catalog['streams']:
             stream_id = stream['tap_stream_id']

--- a/tap_github/gitlocal.py
+++ b/tap_github/gitlocal.py
@@ -14,7 +14,6 @@ class GitLocalException(Exception):
 logger = singer.get_logger()
 
 def parseDiffLines(lines):
-  #ogger.info("parseDiffLines() called for %d lines", len(lines))
   changes = []
   curChange = None
   state = 'start'
@@ -165,7 +164,6 @@ class GitLocal:
 
   def hasLocalCommit(self, repo, sha):
     repoDir = self._getRepoWorkingDir(repo)
-    #ogger.info("Running git log -n1 %s", sha)
     completed = subprocess.run(['git', 'log', '-n1', sha], cwd=repoDir, capture_output=True)
     if completed.stderr.decode('utf-8', errors='replace').find('fatal: bad object') != -1:
       return False
@@ -196,7 +194,6 @@ class GitLocal:
     if offset:
       params.append('--skip={}'.format(int(offset)))
     params.append(headSha)
-    #ogger.info("Running %s", ' '.join(params))
     completed = subprocess.run(params, cwd=repoDir, capture_output=True)
     if completed.returncode != 0:
       # Don't send the acces token through the error logging system
@@ -249,7 +246,6 @@ class GitLocal:
     head has already been fetched and this commit is available.
     """
     repoDir = self._getRepoWorkingDir(repo)
-    #ogger.info("Running git diff for %s", sha)
     completed = subprocess.run(['git', 'diff', sha + '~1', sha], cwd=repoDir, capture_output=True)
     # Special case -- first commit, diff instead with an empty tree
     if completed.returncode != 0 and b"~1': unknown revision or path not in the working tree" \


### PR DESCRIPTION
Updates the gitlocal library to take in the clone URL format as a parameter to support different data sources besides github.

Also adds an HMAC parameter to let the caller specify a token for saving a limited HMAC digest of each code line instead of the code itself, which will reduce the risk of exposing code.

## How was this tested?
- Ran on repotest using scheduled with and without the hmac argument. Observed correct replacement of code with hashes in the diff when the hmac argument was present, and that nothing changed when it wasn't present.
