### PR TITLE
Add id to refs table

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -58,7 +58,7 @@ KEY_PROPERTIES = {
     'projects_v2_issues': ['id'],
     'project_columns': ['id'],
     'project_cards': ['id'],
-    'refs': ['ref'],
+    'refs': ['id'],
     'repos': ['id'],
     'teams': ['id'],
     'team_members': ['id'],
@@ -2002,6 +2002,7 @@ def get_all_commit_files(schemas, repo_path,  state, mdata, start_date, gitLocal
 
             # Emit the ref record as well
             refRecord = {
+                'id': '{}/{}'.format(repo_path, headRef),
                 '_sdc_repository': repo_path,
                 'ref': headRef,
                 'sha': headSha

--- a/tap_github/schemas/refs.json
+++ b/tap_github/schemas/refs.json
@@ -1,6 +1,9 @@
 {
   "type": ["null", "object"],
   "properties": {
+    "id": {
+      "type": ["string"]
+    },
     "_sdc_repository": {
       "type": ["string"]
     },


### PR DESCRIPTION
Uses `id` instead of `ref` as the key property to allow ensure uniqueness when multiple repositories have identical ref names.