### PR TITLE
Filter artifacts that have expired so we don't try and fetch them

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1273,7 +1273,7 @@ def get_all_code_coverage(schemas, repo_path, state, mdata, start_date):
                     stream_name,
                     'https://api.github.com/repos/{}/actions/artifacts?name={}'.format(repo_path, artifact_name_encoded)
             ):
-                artifacts = response.json()['artifacts']
+                artifacts = filter(lambda a: a['expired'] != True, response.json()['artifacts'])
                 for artifact in artifacts:
                     # skip records that haven't been updated since the last run.
                     # the GitHub API doesn't currently allow a `?since` param for artifacts, so we have


### PR DESCRIPTION

## How was this tested
1. Ran tap locally and ensured that expired artifacts are not fetched

Observed error in log
```
CRITICAL HTTP-error-code: 410, URL: https://api.github.com/repos/*****/****/actions/artifacts/708238332/zip. Error: {'message': 'Artifact has expired', 'documentation_url': 'https://docs.github.com/rest/actions/artifacts#download-an-artifact'}
Traceback (most recent call last):
  File "/opt/tap-github/bin/tap-github", line 8, in <module>
    sys.exit(main())
  File "/opt/tap-github/lib/python3.9/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/tap-github/lib/python3.9/site-packages/tap_github/__init__.py", line 2419, in main
    do_sync(args.config, args.state, catalog)
  File "/opt/tap-github/lib/python3.9/site-packages/tap_github/__init__.py", line 2377, in do_sync
    state = sync_func(stream_schema, repo, state, mdata, start_date)
  File "/opt/tap-github/lib/python3.9/site-packages/tap_github/__init__.py", line 1290, in get_all_code_coverage
    data = authed_get(stream_name, artifact['archive_download_url'])
  File "/opt/tap-github/lib/python3.9/site-packages/tap_github/__init__.py", line 304, in authed_get
    raise_for_error(resp, source, url)
  File "/opt/tap-github/lib/python3.9/site-packages/tap_github/__init__.py", line 249, in raise_for_error
    raise exc(message) from None
tap_github.GoneError: HTTP-error-code: 410, URL: https://api.github.com/repos/****/****/actions/artifacts/708238332/zip. Error: {'message': 'Artifact has expired', 'documentation_url': 'https://docs.github.com/rest/actions/artifacts#download-an-artifact'}
```