### PR TITLE
Skip unavailable repos with config parameter

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2735,6 +2735,13 @@ def do_sync(config, state, catalog):
     for repo in allRepos:
         logger.info("Starting sync of repository: %s", repo)
 
+        if 'skip_unavailable' in config and bool(config['skip_unavailable']):
+            try:
+                get_repo_metadata(repo)
+            except:
+                logger.warning(f'{repo} is not available, skipping')
+                continue
+
         org = repo.split('/')[0]
         access_token = set_auth_headers(config, org)
 


### PR DESCRIPTION
## How was this tested
- Planted unavailable repo in allRepos list
- Tested without skip_unavailable in config
- [x] verified failed when trying to sync repo
- Tested with skip_unavailable in config set to false
- [x] verified failed when trying to sync repo
- Tested with skip_unavailable in config set to true
- [x] verified skipped unavailable repo
