### PR TITLE
update exception handling to better handle keys that might not be there

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -1094,7 +1094,8 @@ def authed_graphql_all_pages(source, query_template, query_values, path, page_si
         errors = data.get('errors')
         # check for errors
         if errors is not None:
-            if any(err['type'] in ['FORBIDDEN', 'INSUFFICIENT_SCOPES'] for err in errors):
+            logger.info('GraphQL call failed with query: %s', query)            
+            if any(err.get('type') in ['FORBIDDEN', 'INSUFFICIENT_SCOPES'] for err in errors):
                 raise AuthException(errors[0]['message'], data)
             logger.error('GraphQL query failed on page {}: {}'.format(i + 1, errors))
             raise Exception('GraphQL query failed', errors)


### PR DESCRIPTION
MW-5524

1. Update logging to provide additional context when we run into an error making graphql queries
2. Handle getting err['type'] in a way that won't throw

I am unable to repro this locally so will test this in production.