### PR TITLE
Use search api to find all repos associated with a user, not just pub…

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -574,18 +574,26 @@ def getAccountType(org):
 
     return accountTypeCache[org]
 
-def getReposForOrg(org):
-    acctPathComponent = 'users' if getAccountType(org) == 'USER' else 'orgs'
+def getReposForOrg(user_or_org):
+    if getAccountType(user_or_org) == 'USER':
+        repos_url = f'{api_url}search/repositories?q=user:{user_or_org}&per_page=100'
+    else:
+        repos_url += f'{api_url}orgs/{user_or_org}/repos?per_page=100'
+
     orgRepos = []
     for response in authed_get_all_pages(
         'repositories',
-        f'{api_url}{acctPathComponent}/{org}/repos?per_page=100'
+        repos_url,
     ):
-        repos = response.json()
+        json_response = response.json()
+        repos = json_response
+        if repos_url.startswith(f'{api_url}search'):
+            repos = repos.get('items', [])
+ 
         for repo in repos:
             # Preserve the case used for the org name originally
             namesplit = repo['full_name'].split('/')
-            orgRepos.append(org + '/' + namesplit[1])
+            orgRepos.append(user_or_org + '/' + namesplit[1])
             repo_cache[repo['full_name']] = repo
 
     return orgRepos

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -578,7 +578,7 @@ def getReposForOrg(user_or_org):
     if getAccountType(user_or_org) == 'USER':
         repos_url = f'{api_url}search/repositories?q=user:{user_or_org}&per_page=100'
     else:
-        repos_url += f'{api_url}orgs/{user_or_org}/repos?per_page=100'
+        repos_url = f'{api_url}orgs/{user_or_org}/repos?per_page=100'
 
     orgRepos = []
     for response in authed_get_all_pages(


### PR DESCRIPTION
According to https://github.com/orgs/community/discussions/24382 , we have been using the wrong API to fetch repositories for a particular user.

## How was this tested
- [x] Ran without changes, ran following command on output `cat github-repositories_outfile.log  | grep "\"type\": \"RECORD\"" | jq -r .record.id`, verified only contained public repos
```
github:myleshenderson/myleshenderson.github.io
github:myleshenderson/onboarding
github:myleshenderson/peloton-to-garmin
github:myleshenderson/sicp-vscode
github:myleshenderson/skyhopper
```

- [x] Ran locally with these changes, ran following command on output `cat github-repositories_outfile_after.log  | grep "\"type\": \"RECORD\"" | jq -r .record.id`, verified output contained all repos
```
github:myleshenderson/onboarding
github:myleshenderson/reflex-td
github:myleshenderson/sicp-vscode
github:myleshenderson/obsidian
github:myleshenderson/DailySummary
github:myleshenderson/njs
github:myleshenderson/sicp-journal
github:myleshenderson/PlacesUI
github:myleshenderson/OrgStates
github:myleshenderson/contact-processor
github:myleshenderson/th
github:myleshenderson/Deep
github:myleshenderson/PlacesApi
github:myleshenderson/myleshenderson.github.io
github:myleshenderson/main-obsidian
github:myleshenderson/tutorial-nextjs
```
- [x] Tested with `minwareco/*` to verify org repos were still discovered