### PR TITLE
handle orgs without repos

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -581,20 +581,27 @@ def getReposForOrg(user_or_org):
         repos_url = f'{api_url}orgs/{user_or_org}/repos?per_page=100'
 
     orgRepos = []
-    for response in authed_get_all_pages(
-        'repositories',
-        repos_url,
-    ):
-        json_response = response.json()
-        repos = json_response
-        if repos_url.startswith(f'{api_url}search'):
-            repos = repos.get('items', [])
- 
-        for repo in repos:
-            # Preserve the case used for the org name originally
-            namesplit = repo['full_name'].split('/')
-            orgRepos.append(user_or_org + '/' + namesplit[1])
-            repo_cache[repo['full_name']] = repo
+    try:
+        for response in authed_get_all_pages(
+            'repositories',
+            repos_url,
+        ):
+            json_response = response.json()
+            repos = json_response
+            if repos_url.startswith(f'{api_url}search'):
+                repos = repos.get('items', [])
+     
+            for repo in repos:
+                # Preserve the case used for the org name originally
+                namesplit = repo['full_name'].split('/')
+                orgRepos.append(user_or_org + '/' + namesplit[1])
+                repo_cache[repo['full_name']] = repo
+    except UnprocessableError as e:
+        # Log the error but don't raise an exception
+        # we end up here if there are no repos for the org
+        logger.warning(f"Unable to get repositories for {user_or_org}: {str(e)}")
+        # Return empty list instead of raising exception
+        return []
 
     return orgRepos
 


### PR DESCRIPTION
This handles 422 errors when getting repositories. 
We get those errors when there are no repositories associated with the org.

I validated with Susan's test org that we got the error when there were no repositories. When she added one, the error went away. 

I then validated this change for the other orgs which received the error and the job completes without issue.