### PR TITLE
Myles/mw 5522 update using pat logic

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -39,6 +39,8 @@ graphql_url = ''
 session = requests.Session()
 logger = SecureLogger(singer.get_logger())
 
+using_pat = False
+
 REQUIRED_CONFIG_KEYS = ['start_date', 'access_token', 'repository']
 
 KEY_PROPERTIES = {
@@ -306,12 +308,6 @@ def authed_get(source, url, headers={}, overrideMethod='get', data=None):
         just_refreshed_token = False
         network_retry_count = 0
         network_max_retries = 5
-        
-        # Check if we're using a PAT or GitHub App
-        using_pat = False
-        auth_header = session.headers.get('authorization', '')
-        if auth_header.startswith('token '):
-            using_pat = True
         
         while True:
             try:
@@ -2847,10 +2843,12 @@ def do_sync(config, state, catalog):
 def main():
     global latest_response
     global latest_request
+    global using_pat
     
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     if args.config and 'access_token' in args.config:
         logger.addToken(args.config['access_token'])
+        using_pat = True
 
     try:
         if args.discover:

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -626,11 +626,13 @@ def getOrgs():
     return orgs
 
 def set_auth_headers(config, org = None):
+    global using_pat
     access_token = config['access_token']
 
     # If we don't have a personal access token, use the github app to get an installation access
     # token
     if not access_token or len(access_token) == 0:
+        using_pat = False
         if not org:
             raise Exception('Org value must be provided when authorizing with an app installation key')
         elif org in cached_app_tokens:
@@ -639,6 +641,7 @@ def set_auth_headers(config, org = None):
         appid = config['app_id']
         access_token = refresh_app_token(pem, appid, org)
     else:
+        using_pat = True
         session.headers.update({'authorization': 'token ' + access_token})
 
     logger.addToken(access_token)
@@ -2840,16 +2843,16 @@ def do_sync(config, state, catalog):
         # right now and running out of memory as a result.
         singer.write_state(state)
 
+
+
 def main():
     global latest_response
     global latest_request
-    global using_pat
     
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     if args.config and 'access_token' in args.config:
         logger.addToken(args.config['access_token'])
-        using_pat = True
-
+        
     try:
         if args.discover:
             do_discover(args.config)


### PR DESCRIPTION
This improves how we determine that we are using a PAT. The previous logic was incorrect and always resulted in using_pat = true. This wasn't apparent until we had a long running sync where the PEM auth expired and we needed to refresh it.

Validated by using a PAT and non-PAT org and seeing that the value is set as expected and that auth works as expected (for the length of time that I let the ingest run).