### PR TITLE
Set auth headers before making metadata call

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2801,15 +2801,15 @@ def do_sync(config, state, catalog):
     for repo in allRepos:
         logger.info("Starting sync of repository: %s", repo)
 
+        org = repo.split('/')[0]
+        access_token = set_auth_headers(config, org)
+
         if 'skip_unavailable' in config and bool(config['skip_unavailable']):
             try:
                 get_repo_metadata(repo)
             except:
                 logger.warning(f'{repo} is not available, skipping')
                 continue
-
-        org = repo.split('/')[0]
-        access_token = set_auth_headers(config, org)
 
         gitLocal = GitLocal({
             'access_token': access_token,


### PR DESCRIPTION
# Manual QA steps
 - Generated github token
 - Ran locally with reset_state and verified skip_unavailable properly skips unavailable repos and processes existing repos