### PR TITLE
add issue type object to issue_events catalog

### DIFF
--- a/tap_github/schemas/issue_events.json
+++ b/tap_github/schemas/issue_events.json
@@ -822,6 +822,64 @@
               }
             }
           }
+        },
+        "type": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "node_id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "color": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "created_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            },
+            "is_enabled": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Not tested yet, but will run an ingest to validate after adding the fields to the database.

