### PR TITLE
handle 404 when getting issue_types

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -960,7 +960,6 @@ def get_all_issue_types(schemas, repo_path, state, mdata, _start_date):
             logger.warn('issue_types data could not be ingested because authorization failed on the API endpoint')
         except NotFoundException as e:
             # for personal/non-organization accounts, the API endpoint returns 404
-
             logger.warn('issue_types data could not be ingested because the API endpoint returned 404')
 
     return state


### PR DESCRIPTION
Github returns a 404 if the account we're operating against isn't a org account. This catches that exception and logs a warning.