### PR TITLE
implement commit only mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "ed93cc7553bb756c7e68d83435029da8f42742c0"
+UTILS_VERSION = "955a167aefb67b957ee2eea2369327111f8bd802"
 
 setup(name='tap-github',
       version='1.10.0',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "955a167aefb67b957ee2eea2369327111f8bd802"
+UTILS_VERSION = "52a7ce3dbe9b96a6a09e9e9ce029b2840a9eb937"
 
 setup(name='tap-github',
       version='1.10.0',

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2850,6 +2850,8 @@ def do_sync(config, state, catalog):
     for repo in allRepos:
         logger.info("Starting sync of repository: %s", repo)
 
+        commits_only = 'commit_files_meta' in selected_stream_ids
+
         org = repo.split('/')[0]
         access_token = set_auth_headers(config, org)
 
@@ -2866,7 +2868,7 @@ def do_sync(config, state, catalog):
         }, 'https://x-access-token:{}@github.com/{}.git',
             config['hmac_token'] if 'hmac_token' in config else None,
             logger=logger,
-            commitsOnly='commit_files_meta' in selected_stream_ids)
+            commitsOnly=commits_only)
 
         for stream in catalog['streams']:
             stream_id = stream['tap_stream_id']
@@ -2904,7 +2906,6 @@ def do_sync(config, state, catalog):
 
                     # sync stream and its sub streams
                     if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
-                        commits_only = stream_id == 'commit_files_meta'
                         state = sync_func(stream_schemas, repo, state, mdata, start_date,
                             gitLocal, commits_only)
                     else:

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2744,7 +2744,7 @@ SUB_STREAMS = {
     'pull_requests': ['reviews', 'review_comments'],
     'projects': ['project_cards', 'project_columns'],
     'teams': ['team_members', 'team_memberships'],
-    'commit_files_meta': ['refs'],
+    'commit_files': ['refs'],
     'workflow_runs': ['workflow_run_jobs'],
     'deployments': ['deployment_statuses']
 }

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2745,6 +2745,7 @@ SUB_STREAMS = {
     'projects': ['project_cards', 'project_columns'],
     'teams': ['team_members', 'team_memberships'],
     'commit_files': ['refs'],
+    'commit_files_meta': ['refs'],
     'workflow_runs': ['workflow_run_jobs'],
     'deployments': ['deployment_statuses']
 }

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2744,7 +2744,6 @@ SUB_STREAMS = {
     'pull_requests': ['reviews', 'review_comments'],
     'projects': ['project_cards', 'project_columns'],
     'teams': ['team_members', 'team_memberships'],
-    'commit_files': ['refs'],
     'commit_files_meta': ['refs'],
     'workflow_runs': ['workflow_run_jobs'],
     'deployments': ['deployment_statuses']

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2374,7 +2374,7 @@ async def getChangedfilesForCommits(commits, repo_path, hasLocal, gitLocal):
     results = await asyncio.gather(*coros)
     return results
 
-def get_all_commit_files(schemas, repo_path,  state, mdata, start_date, gitLocal, commits_only=False):
+def get_all_commit_files(schemas, repo_path,  state, mdata, start_date, gitLocal, commits_only=False, selected_stream_ids=None):
     # Get the set of all commits we have fetched previously
     stream_name = 'commit_files_meta' if commits_only else 'commit_files'
     fetchedCommits = get_bookmark(state, repo_path, stream_name, "fetchedCommits")
@@ -2419,8 +2419,8 @@ def get_all_commit_files(schemas, repo_path,  state, mdata, start_date, gitLocal
                 #logger.info('Head already fetched {} {}'.format(headRef, headSha))
                 continue
 
-            # Emit the ref record as well (only in regular mode, not commit-only)
-            if not commits_only:
+            # Emit the ref record as well (only if refs stream is selected)
+            if selected_stream_ids and 'refs' in selected_stream_ids:
                 refRecord = {
                     'id': '{}/{}'.format(repo_path, headRef),
                     '_sdc_repository': repo_path,
@@ -2894,7 +2894,7 @@ def do_sync(config, state, catalog):
                     if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
                         commits_only = stream_id == 'commit_files_meta'
                         stream_schemas = {stream_id: stream_schema}
-                        state = sync_func(stream_schemas, repo, state, mdata, start_date, gitLocal, commits_only)
+                        state = sync_func(stream_schemas, repo, state, mdata, start_date, gitLocal, commits_only, selected_stream_ids)
                     else:
                         state = sync_func(stream_schema, repo, state, mdata, start_date)
 
@@ -2913,7 +2913,7 @@ def do_sync(config, state, catalog):
                     # sync stream and its sub streams
                     if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
                         state = sync_func(stream_schemas, repo, state, mdata, start_date,
-                            gitLocal, commits_only)
+                            gitLocal, commits_only, selected_stream_ids)
                     else:
                         state = sync_func(stream_schemas, repo, state, mdata, start_date)
         # Write the state after each repo. There use to be a check for:

--- a/tap_github/schemas/commit_files_meta.json
+++ b/tap_github/schemas/commit_files_meta.json
@@ -1,0 +1,124 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
+    "id": {
+      "type": ["null", "string"],
+      "description": "Unique identifier of commit, <_sdc_repository>/<sha>"
+    },
+    "sha": {
+      "type": ["null", "string"],
+      "description": "The git commit hash"
+    },
+    "parents": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "sha": {
+            "type": ["null", "string"],
+            "description": "The git hash of the parent commit"
+          }
+        }
+      }
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "properties": {
+        "tree": {
+          "type": ["null", "object"],
+          "properties": {
+            "sha": {
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "author": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the author committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The author's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The author's email"
+            }
+          }
+        },
+        "message": {
+          "type": ["null", "string"],
+          "description": "The commit message"
+        },
+        "committer": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the committer committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The committer's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The committer's email"
+            }
+          }
+        }
+      }
+    },
+    "files": {
+      "type": ["array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "filename": {
+            "type": ["string"],
+            "description": "The full name of the file including its directory path, unique per commit"
+          },
+          "previous_filename": {
+            "type": ["null", "string"],
+            "description": "If the file was renamed, this was its full name in the parent commit"
+          },
+          "patch": {
+            "type": ["null", "string"],
+            "description": "A patch representing the changes to the file in this commit."
+          },
+          "is_binary": {
+            "type": ["boolean"],
+            "description": "The file is binary, so no patch is included and change counts are zero. Binary is determined by the presence of null bytes or sequences that cause UTF-8 decoding errors. This flag will not be set when adding binary files becuase those are indiscernable from adding zero-length files in the github api."
+          },
+          "is_large_patch": {
+            "type": ["boolean"],
+            "description": "The file is text, but the current patch was too large to include (> 1 MB). Change counts may or may not be non-zero."
+          },
+          "changetype": {
+            "type": ["string"],
+            "description": "The type of change -- one of: add, delete, edit, none. None means no change to the file, which may be the case if there's a rename."
+          },
+          "additions": {
+            "type": ["integer"],
+            "description": "The number of lines added by this change (0 for binary or large patch)."
+          },
+          "deletions": {
+            "type": ["integer"],
+            "description": "The number of lines deleted by this change (0 for binary or large patch)."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change allows us to process the commit files meta job. 

Ran a github ingest that completed successfully (just the source -> jsonl part).

I have validated this by running commit files meta and commit files jobs and observed that the files make it into S3.

Then I ran an s3 -> snowflake job and saw that we get the records as expected in the source schema.

```
Select * from T_7875C5067419433C84FD656541FE7F3A_GITHUB.COMMIT_FILES_META where _sdc_repository = 'myleshenderson/config';
Select * from T_7875C5067419433C84FD656541FE7F3A_GITHUB.COMMIT_FILES where _sdc_repository = 'myleshenderson/config';
```
<img width="847" alt="image" src="https://github.com/user-attachments/assets/a35c9860-b8ba-4e5f-9489-50bfd672eb4c" />
