### PR TITLE
fix to ensure we don't have negative values

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -305,7 +305,9 @@ def raise_for_error(resp, source, url):
 
 def calculate_seconds(epoch):
     current = time.time()
-    return int(round((epoch - current), 0))
+    seconds = int(round((epoch - current), 0))
+    # Ensure we never return negative sleep time
+    return max(0, seconds)
 
 def rate_throttling(response):
     """Simple proactive rate limiting - called after successful requests"""


### PR DESCRIPTION
Update to ensure that when the reset time has already passed, we should retry immediately (sleep 0) rather than crashing with a negative sleep value.

Validated by updating unit tests and also running dev ingest for an org. The real test though will be in production.