### PR TITLE
MW-11084: Extract pushed_at from repositories (Phase 1)

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -2902,6 +2902,7 @@ def get_repository_data(schema, repo_path, state, mdata, _start_date):
         repo['fork_repo_name'] = fork_repo_name
         repo['description'] = repo_metadata['description']
         repo['is_fork'] = repo_metadata.get('fork', None)
+        repo['pushed_at'] = repo_metadata.get('pushed_at', None)
         with singer.Transformer() as transformer:
             rec = transformer.transform(repo, schema, metadata=metadata.to_map(mdata))
         singer.write_record('repositories', rec, time_extracted=extraction_time)

--- a/tap_github/schemas/repositories.json
+++ b/tap_github/schemas/repositories.json
@@ -58,6 +58,13 @@
                 "null",
                 "boolean"
             ]
+        },
+        "pushed_at": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
         }
     }
 }


### PR DESCRIPTION
## Summary
Part of MW-11084: Skip unchanged repos during GitHub ingest

Extracts `pushed_at` timestamp from GitHub repository metadata:
- Add `pushed_at` to repositories schema
- Extract value in `get_repository_data()`
- Target-reposync maps this to `source_updated_at` column

## Phase
Phase 1: Data collection only. No behavior change until orchestrator filtering is deployed (Phase 2).

## Related PRs
- app: Add DB columns
- scheduled: Catalog update
- target-reposync: Map to `source_updated_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)